### PR TITLE
Add pre-processor syntax highlighting support

### DIFF
--- a/syntaxes/polymer-syntax.json
+++ b/syntaxes/polymer-syntax.json
@@ -96,6 +96,44 @@
 			"include": "#embedded-code"
 		},
 		{
+			"begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=('sass'|\"sass\"))(?![^>]*/>)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.html.polymer"
+				},
+				"2": {
+					"name": "entity.name.tag.style.html.polymer"
+				},
+				"3": {
+					"name": "punctuation.definition.tag.html.polymer"
+				}
+			},
+			"end": "(</)((?i:style))(>)(?:\\s*\\n)?",
+			"patterns": [
+				{
+					"include": "#tag-stuff"
+				},
+				{
+					"contentName": "source.sass.embedded.html.polymer",
+					"begin": "(>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.html.polymer"
+						}
+					},
+					"end": "(?=</(?i:style))",
+					"patterns": [
+						{
+							"include": "#embedded-code"
+						},
+						{
+							"include": "source.sass"
+						}
+					]
+				}
+			]
+		},
+		{
 			"begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=('scss'|\"scss\"))(?![^/>]*/>\\s*$)",
 			"captures": {
 				"1": {

--- a/syntaxes/polymer-syntax.json
+++ b/syntaxes/polymer-syntax.json
@@ -96,6 +96,44 @@
 			"include": "#embedded-code"
 		},
 		{
+			"begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=('less'|\"less\"))(?![^>]*/>)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.html.polymer"
+				},
+				"2": {
+					"name": "entity.name.tag.style.html.polymer"
+				},
+				"3": {
+					"name": "punctuation.definition.tag.html.polymer"
+				}
+			},
+			"end": "(</)((?i:style))(>)(?:\\s*\\n)?",
+			"patterns": [
+				{
+					"include": "#tag-stuff"
+				},
+				{
+					"contentName": "source.css.less.embedded.html.polymer",
+					"begin": "(>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.html.polymer"
+						}
+					},
+					"end": "(?=</(?i:style))",
+					"patterns": [
+						{
+							"include": "#embedded-code"
+						},
+						{
+							"include": "source.css.less"
+						}
+					]
+				}
+			]
+		},
+		{
 			"begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=('sass'|\"sass\"))(?![^>]*/>)",
 			"captures": {
 				"1": {

--- a/syntaxes/polymer-syntax.json
+++ b/syntaxes/polymer-syntax.json
@@ -96,6 +96,44 @@
 			"include": "#embedded-code"
 		},
 		{
+			"begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=('scss'|\"scss\"))(?![^/>]*/>\\s*$)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.tag.html.polymer"
+				},
+				"2": {
+					"name": "entity.name.tag.style.html.polymer"
+				},
+				"3": {
+					"name": "punctuation.definition.tag.html.polymer"
+				}
+			},
+			"end": "(</)((?i:style))(>)(?:\\s*\\n)?",
+			"patterns": [
+				{
+					"include": "#tag-stuff"
+				},
+				{
+					"contentName": "source.css.scss.embedded.html.polymer",
+					"begin": "(>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.html.polymer"
+						}
+					},
+					"end": "(?=</(?i:style))",
+					"patterns": [
+						{
+							"include": "#embedded-code"
+						},
+						{
+							"include": "source.css.scss"
+						}
+					]
+				}
+			]
+		},
+		{
 			"begin": "(?:^\\s+)?(<)((?i:style))\\b(?![^>]*/>)",
 			"captures": {
 				"1": {


### PR DESCRIPTION
Hi there @JonathanWolfe. 
I got syntax highlighting to work for scss as discussed in #5 (see gif). Is there something else I should test out you think?


![polymer lang](https://user-images.githubusercontent.com/1515742/37421221-0e377c78-27b9-11e8-8408-647f18c77382.gif)
